### PR TITLE
feat: add min and max temperatures

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,6 +57,8 @@ const App = () => {
         const days = sortDays(weathers.days).map(day => ({
             datetime: day.datetime,
             temp: day.temp,
+            tempmax: day.tempmax,
+            tempmin: day.tempmin,
         }))
 
         dispatch({
@@ -129,6 +131,15 @@ const App = () => {
                                         rel='noopener noreferrer'
                                     >
                                         Global Climate Change – NASA
+                                    </a>
+                                </li>
+                                <li>
+                                    <a
+                                        href='https://www.nrdc.org/stories/global-warming-101'
+                                        target='_blank'
+                                        rel='noopener noreferrer'
+                                    >
+                                        Global Warming 101
                                     </a>
                                 </li>
                             </ul>

--- a/src/components/weather-box.js
+++ b/src/components/weather-box.js
@@ -72,6 +72,19 @@ const Year = styled.h3`
     font-weight: 500;
 `
 
+const MinMaxWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+`
+
+const MinMax = styled.div`
+    font-size: 1rem;
+    flex: 1 1 auto;
+    font-weight: 300;
+    border-radius: 8px;
+`
+
 export const WeatherBox = ({ days, locationName }) => {
     return (
         <WeatherContainer hue={getHue(days)}>
@@ -92,17 +105,23 @@ export const WeatherBox = ({ days, locationName }) => {
                                 <Year>
                                     {new Date(day.datetime).getFullYear()}
                                 </Year>
-                                <Temperature>
-                                    {day.temp !== null ? `${day.temp} ºC` : 'No data'}
-                                </Temperature>
+                                <Temperature>{`${day.temp} ºC`}</Temperature>
+                                <MinMaxWrapper>
+                                    <MinMax>{`Min ${day.tempmin} ºC`}</MinMax>
+                                    <MinMax>{`Max ${day.tempmax} ºC`}</MinMax>
+                                </MinMaxWrapper>
                             </Day>
                         </Tippy>
                     ) : (
                         <Day key={day.datetime} temp={day.temp}>
                             <Year>{new Date(day.datetime).getFullYear()}</Year>
-                            <Temperature>
-                                {day.temp !== null ? `${day.temp} ºC` : 'No data'}
-                            </Temperature>
+                            <Temperature
+                                key={day.datetime}
+                            >{`${day.temp} ºC`}</Temperature>
+                            <MinMaxWrapper>
+                                <MinMax>{`Min ${day.tempmin} ºC`}</MinMax>
+                                <MinMax>{`Max ${day.tempmax} ºC`}</MinMax>
+                            </MinMaxWrapper>
                         </Day>
                     ),
                 )}

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -22,31 +22,43 @@ export const handlers = [
                         datetime: '2021-02-21',
                         temp:
                             location.toLowerCase() === 'estonia' ? -13.1 : 13.1,
+                        tempmax: 13,
+                        tempmin: 4,
                     },
                     {
                         datetime: '2011-02-21',
                         temp:
                             location.toLowerCase() === 'estonia' ? -11.0 : 11.0,
+                        tempmax: 13.5,
+                        tempmin: 4.2,
                     },
                     {
                         datetime: '2001-02-21',
                         temp:
                             location.toLowerCase() === 'estonia' ? -18.8 : 8.8,
+                        tempmax: 8.5,
+                        tempmin: 4.2,
                     },
                     {
                         datetime: '1991-02-21',
                         temp:
                             location.toLowerCase() === 'estonia' ? -11.2 : 11.2,
+                        tempmax: 13.5,
+                        tempmin: 4.2,
                     },
                     {
                         datetime: '1981-02-21',
                         temp:
                             location.toLowerCase() === 'estonia' ? -13.6 : 3.6,
+                        tempmax: 13.5,
+                        tempmin: 4.2,
                     },
                     {
                         datetime: '1973-02-21',
                         temp:
                             location.toLowerCase() === 'estonia' ? -17.5 : 7.5,
+                        tempmax: 23.5,
+                        tempmin: 14.2,
                     },
                 ],
             }),


### PR DESCRIPTION
Agrego las temperaturas min y max de cada día, para dar un poco más de información sin tener que hacer que las queries sean más costosas (pidiendo más días).

![image](https://user-images.githubusercontent.com/7825875/109080244-7fa29980-7700-11eb-8148-5fa3b9e89760.png)


@albarin si tenés ganas de hacer el cambio en la API, metele. Si no llegás lo hago yo mañana ❤️ 